### PR TITLE
Refactor pedTail/tail.cpp for more robust tailing and simpler logic

### DIFF
--- a/CPlusPlus/pedTail/tail.cpp
+++ b/CPlusPlus/pedTail/tail.cpp
@@ -1,139 +1,147 @@
-#include <stdlib.h>
-#include <stdio.h>
+#include <errno.h>
 #include <io.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <Windows.h>
 
-void  main(int argc, char* argv[])
+namespace {
+constexpr __int64 kInitialTailBytes = 512;
+constexpr size_t kChunkSize = 1024;
+constexpr DWORD kPollDelayMs = 5000;
+
+__int64 get_file_size(FILE* stream)
 {
-	if ( argc != 2)
-	{
-		printf("Simple binary 'Tail' program for Windows.\n");
-		printf("Usage: pedTail <input file> \n\n");
-		return;
-	}
-	
-	const char* v_FileName_in = (const char*)argv[1];
-	
-	__int64 v_size = 512;
-    
-	#define CHUNK_SIZE 1024
-	static char v_buffer[CHUNK_SIZE];
+    return _filelengthi64(_fileno(stream));
+}
 
-	size_t v_count;
-	__int64 v_len;
-	__int64 v_len2;
-	__int64 v_offset;
+bool seek_to_offset(FILE* stream, __int64 offset)
+{
+    return _fseeki64(stream, offset, SEEK_SET) == 0;
+}
 
-again:
-	FILE* stream_in;
-	stream_in = fopen(v_FileName_in, "rb");   // use fopen, in favor of fopen_s
-	if( stream_in == NULL )
-	{
-		printf("Unable to open input file %s\n\n", v_FileName_in);
-		return;
-	}
+bool write_range(FILE* stream, __int64 bytes_to_write)
+{
+    static unsigned char buffer[kChunkSize];
 
-	v_len = _filelength(_fileno(stream_in));
+    while (bytes_to_write > 0)
+    {
+        const size_t request = bytes_to_write > static_cast<__int64>(kChunkSize)
+            ? kChunkSize
+            : static_cast<size_t>(bytes_to_write);
 
-	v_size = v_len > v_size ? v_size : v_len;
-
-	v_offset = v_len-v_size;
-	
-	fsetpos(stream_in, &v_offset);
-	printf("Starting at offset %lld\n\n", v_offset);
-
-	while (v_size > 0)
-	{
-		if (v_size > CHUNK_SIZE)
-		{
-			v_count = fread(v_buffer, sizeof(char), CHUNK_SIZE, stream_in);
-		}
-		else
-		{
-			v_count = fread(v_buffer, sizeof(char), v_size, stream_in);
-		}
-
-		if (v_count != v_size)
-		{
-			printf("error reading file");
-			return;
-		}
-
-		v_count = fwrite(v_buffer, 1, v_count, stdout);
-		(v_count > 0) ? v_size -= v_count : v_size = 0;
-	}
-	fclose(stream_in);
-
-	Sleep(5000);
-
-    while(1)
-	{
-		stream_in = fopen(v_FileName_in, "rb");   // use fopen, in favor of fopen_s
-		if( stream_in == NULL )
-		{
-			printf("Unable to open input file %s\n\n", v_FileName_in);
-			return;
-		}
-
-		//Get  the new length
-		v_len2 = _filelength(_fileno(stream_in));
-
-		if(v_len2 > v_len)
+        const size_t bytes_read = fread(buffer, 1, request, stream);
+        if (bytes_read != request)
         {
-			v_size =v_len2-v_len;
-			v_offset =v_len2-v_size;
+            printf("error reading file\n");
+            return false;
+        }
 
-			//save new lehgth
-            v_len=v_len2;
+        const size_t bytes_written = fwrite(buffer, 1, bytes_read, stdout);
+        if (bytes_written != bytes_read)
+        {
+            printf("error writing output\n");
+            return false;
+        }
 
-			fsetpos(stream_in, &v_offset);
-			while (v_size > 0)
-			{
-				char* pTmp = NULL;
-				if (v_size > CHUNK_SIZE)
-				{
-					v_count = fread(v_buffer,sizeof(char), CHUNK_SIZE, stream_in);
-					if (v_count != CHUNK_SIZE)
-					{
-						printf("error reading file\n");
-						return;
-					}
-					else
-					{
-						pTmp = new char[v_count + 1];
-						pTmp[v_count] = '\0';
-					}
-                }
-				else
-				{
-					v_count = fread(v_buffer, sizeof(char), (int)v_size, stream_in);				
-					if (v_count != v_size)
-					{
-						printf("error reading file\n");
-						return;
-					}
-					else {
-						pTmp = new char[v_count + 1];
-						pTmp[v_count] = '\0';
-					}
-				}				
-                strncpy_s(pTmp, v_count + 1,v_buffer,v_count);
-							
-				printf("%s",pTmp);
+        bytes_to_write -= static_cast<__int64>(bytes_written);
+    }
 
-				delete [] pTmp;
-				pTmp=NULL;
+    fflush(stdout);
+    return true;
+}
 
-				(v_count > 0) ? v_size -= v_count : v_size = 0;
-			}
-		}
-		else if (v_len2 < v_len)
-		{
-			goto again;
-		}
+FILE* open_input(const char* filename)
+{
+    FILE* stream = fopen(filename, "rb");
+    if (stream == NULL)
+    {
+        printf("Unable to open input file %s (errno=%d)\n\n", filename, errno);
+    }
 
-		Sleep(5000);
-	}
-	return;
+    return stream;
+}
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2)
+    {
+        printf("Simple binary 'Tail' program for Windows.\n");
+        printf("Usage: pedTail <input file> \n\n");
+        return EXIT_FAILURE;
+    }
+
+    const char* filename = argv[1];
+
+    FILE* stream = open_input(filename);
+    if (stream == NULL)
+    {
+        return EXIT_FAILURE;
+    }
+
+    __int64 known_size = get_file_size(stream);
+    __int64 initial_bytes = known_size > kInitialTailBytes ? kInitialTailBytes : known_size;
+    const __int64 initial_offset = known_size - initial_bytes;
+
+    if (!seek_to_offset(stream, initial_offset))
+    {
+        printf("Unable to seek to offset %lld\n", initial_offset);
+        fclose(stream);
+        return EXIT_FAILURE;
+    }
+
+    printf("Starting at offset %lld\n\n", initial_offset);
+
+    if (!write_range(stream, initial_bytes))
+    {
+        fclose(stream);
+        return EXIT_FAILURE;
+    }
+
+    fclose(stream);
+
+    while (true)
+    {
+        Sleep(kPollDelayMs);
+
+        stream = open_input(filename);
+        if (stream == NULL)
+        {
+            return EXIT_FAILURE;
+        }
+
+        const __int64 current_size = get_file_size(stream);
+
+        if (current_size < known_size)
+        {
+            // File was truncated/rotated; restart by showing the last window.
+            known_size = current_size > kInitialTailBytes ? kInitialTailBytes : current_size;
+            const __int64 reset_offset = current_size - known_size;
+
+            if (!seek_to_offset(stream, reset_offset) || !write_range(stream, known_size))
+            {
+                fclose(stream);
+                return EXIT_FAILURE;
+            }
+
+            known_size = current_size;
+            fclose(stream);
+            continue;
+        }
+
+        const __int64 delta = current_size - known_size;
+        if (delta > 0)
+        {
+            if (!seek_to_offset(stream, known_size) || !write_range(stream, delta))
+            {
+                fclose(stream);
+                return EXIT_FAILURE;
+            }
+
+            known_size = current_size;
+        }
+
+        fclose(stream);
+    }
 }


### PR DESCRIPTION
### Motivation
- The original `tail.cpp` used `goto`, per-chunk heap allocations, and compared reads to the remaining total which caused incorrect chunked I/O and fragile behavior.
- The intent of the change is to make tailing of files more robust for large/64-bit files, easier to maintain, and safer in the presence of truncation/rotation.

### Description
- Refactored `CPlusPlus/pedTail/tail.cpp` into helper functions `get_file_size`, `seek_to_offset`, `write_range`, and `open_input` to reduce duplication and clarify responsibilities.
- Replaced per-chunk `new`/`delete` allocations with a single reusable static buffer and validated `fread`/`fwrite` against each requested chunk size in `write_range`.
- Switched to explicit 64-bit file APIs (`_filelengthi64` and `_fseeki64`) and improved open/seek error reporting.
- Replaced the `goto` and ad-hoc loop with a clear polling loop that handles file growth and truncation/rotation by restarting the tail window when the file shrinks.

### Testing
- Ran `git -C /workspace/projects diff --check` which produced no whitespace or diff-check issues (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5433aeb8832fbe903675bbe546e4)