### PR TITLE
Create Jira-like draggable task board web app

### DIFF
--- a/jira-board/app.js
+++ b/jira-board/app.js
@@ -1,0 +1,80 @@
+const seedTasks = [
+  { id: crypto.randomUUID(), title: "Define API contract", column: "todo" },
+  { id: crypto.randomUUID(), title: "Build authentication flow", column: "inprogress" },
+  { id: crypto.randomUUID(), title: "Run QA on payment checkout", column: "review" },
+  { id: crypto.randomUUID(), title: "Deploy staging build", column: "done" },
+];
+
+const lists = [...document.querySelectorAll(".task-list")];
+const template = document.getElementById("task-template");
+const form = document.getElementById("new-task-form");
+const titleInput = document.getElementById("new-task-title");
+
+let tasks = [...seedTasks];
+
+function render() {
+  lists.forEach((list) => {
+    list.innerHTML = "";
+    const columnTasks = tasks.filter((task) => task.column === list.dataset.column);
+
+    columnTasks.forEach((task) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      node.dataset.taskId = task.id;
+      node.querySelector(".task-title").textContent = task.title;
+      attachDragHandlers(node);
+      list.appendChild(node);
+    });
+
+    const count = list.closest(".column").querySelector(".task-count");
+    count.textContent = String(columnTasks.length);
+  });
+}
+
+function attachDragHandlers(taskNode) {
+  taskNode.addEventListener("dragstart", (event) => {
+    taskNode.classList.add("dragging");
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", taskNode.dataset.taskId);
+  });
+
+  taskNode.addEventListener("dragend", () => {
+    taskNode.classList.remove("dragging");
+  });
+}
+
+lists.forEach((list) => {
+  list.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    list.classList.add("drag-over");
+    event.dataTransfer.dropEffect = "move";
+  });
+
+  list.addEventListener("dragleave", () => {
+    list.classList.remove("drag-over");
+  });
+
+  list.addEventListener("drop", (event) => {
+    event.preventDefault();
+    list.classList.remove("drag-over");
+    const taskId = event.dataTransfer.getData("text/plain");
+    const targetColumn = list.dataset.column;
+
+    tasks = tasks.map((task) => (task.id === taskId ? { ...task, column: targetColumn } : task));
+    render();
+  });
+});
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const title = titleInput.value.trim();
+
+  if (!title) {
+    return;
+  }
+
+  tasks.unshift({ id: crypto.randomUUID(), title, column: "todo" });
+  titleInput.value = "";
+  render();
+});
+
+render();

--- a/jira-board/index.html
+++ b/jira-board/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jira-like Task Board</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>Project Board</h1>
+      <form id="new-task-form" class="new-task-form">
+        <input id="new-task-title" type="text" placeholder="Add a task title..." maxlength="90" required />
+        <button type="submit">Add Task</button>
+      </form>
+    </header>
+
+    <main class="board" id="board">
+      <section class="column" data-column-id="todo">
+        <div class="column-header">
+          <h2>To Do</h2>
+          <span class="task-count">0</span>
+        </div>
+        <div class="task-list" data-column="todo"></div>
+      </section>
+
+      <section class="column" data-column-id="inprogress">
+        <div class="column-header">
+          <h2>In Progress</h2>
+          <span class="task-count">0</span>
+        </div>
+        <div class="task-list" data-column="inprogress"></div>
+      </section>
+
+      <section class="column" data-column-id="review">
+        <div class="column-header">
+          <h2>Review</h2>
+          <span class="task-count">0</span>
+        </div>
+        <div class="task-list" data-column="review"></div>
+      </section>
+
+      <section class="column" data-column-id="done">
+        <div class="column-header">
+          <h2>Done</h2>
+          <span class="task-count">0</span>
+        </div>
+        <div class="task-list" data-column="done"></div>
+      </section>
+    </main>
+
+    <template id="task-template">
+      <article class="task" draggable="true">
+        <p class="task-title"></p>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/jira-board/style.css
+++ b/jira-board/style.css
@@ -1,0 +1,155 @@
+:root {
+  --bg: #f4f5f7;
+  --column-bg: #ebecf0;
+  --card-bg: #ffffff;
+  --text: #172b4d;
+  --muted: #6b778c;
+  --accent: #0052cc;
+  --accent-soft: #deebff;
+  --border: #dfe1e6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border);
+  background: #fff;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.new-task-form {
+  display: flex;
+  gap: 8px;
+}
+
+.new-task-form input {
+  width: min(360px, 60vw);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  padding: 9px 10px;
+}
+
+.new-task-form button {
+  border: none;
+  border-radius: 6px;
+  padding: 9px 12px;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(240px, 1fr));
+  gap: 12px;
+  padding: 16px;
+  min-height: calc(100vh - 74px);
+  overflow-x: auto;
+}
+
+.column {
+  background: var(--column-bg);
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 106px);
+}
+
+.column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  padding: 3px;
+}
+
+.column-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.task-count {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  min-height: 120px;
+  padding: 4px;
+  border-radius: 8px;
+}
+
+.task-list.drag-over {
+  outline: 2px dashed var(--accent);
+  background: var(--accent-soft);
+}
+
+.task {
+  background: var(--card-bg);
+  border-radius: 8px;
+  padding: 10px;
+  border: 1px solid #cfd4dd;
+  cursor: grab;
+  box-shadow: 0 1px 1px rgba(9, 30, 66, 0.12);
+}
+
+.task:active {
+  cursor: grabbing;
+}
+
+.task.dragging {
+  opacity: 0.45;
+}
+
+.task-title {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.3;
+}
+
+@media (max-width: 960px) {
+  .board {
+    grid-template-columns: repeat(2, minmax(240px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .new-task-form {
+    width: 100%;
+  }
+
+  .new-task-form input {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small standalone web-based task board with a Jira-like multi-column layout so users can create tasks and move them across workflow stages. 
- No external Codex skills were required to implement this feature.

### Description
- Add `jira-board/index.html` which defines a four-column board (To Do, In Progress, Review, Done), a task template, and a top-bar form to create new tasks. 
- Add `jira-board/style.css` to style the board, cards, drag-over states, responsive breakpoints, and column task counts. 
- Add `jira-board/app.js` to seed example tasks, render tasks into columns, handle drag-and-drop moves between columns, and add new tasks into the To Do column.

### Testing
- Ran `node --check jira-board/app.js` which completed without errors. 
- Performed a smoke check by serving the app with `python3 -m http.server` and validating with `curl -I http://127.0.0.1:4273`, which returned HTTP 200. 
- Captured a UI screenshot via Playwright to validate rendering and drag-and-drop UI elements, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4647eac48832fa2bbafb6bc733fa0)